### PR TITLE
Add basic swipe deck with summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>KittenSwipe</title>
+  <link rel="stylesheet" href="src/styles.css" />
+</head>
+<body>
+  <div id="app">
+    <div id="deck" class="deck"></div>
+    <div id="summary" class="summary hidden">
+      <h2>Your favorite kittens</h2>
+      <div id="liked" class="liked"></div>
+    </div>
+  </div>
+  <script type="module" src="src/main.js"></script>
+</body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,89 @@
+const images = [
+  'https://placekitten.com/300/400',
+  'https://placekitten.com/301/400',
+  'https://placekitten.com/300/401',
+  'https://placekitten.com/302/400'
+];
+
+const deck = document.getElementById('deck');
+const summary = document.getElementById('summary');
+const likedContainer = document.getElementById('liked');
+const liked = [];
+
+function createCard(url) {
+  const card = document.createElement('div');
+  card.className = 'card';
+  card.style.backgroundImage = `url(${url})`;
+
+  let startX = 0;
+  let currentX = 0;
+  let dragging = false;
+
+  const onPointerDown = (e) => {
+    startX = e.clientX;
+    dragging = true;
+    card.style.transition = 'none';
+  };
+
+  const onPointerMove = (e) => {
+    if (!dragging) return;
+    currentX = e.clientX - startX;
+    card.style.transform = `translateX(${currentX}px) rotate(${currentX / 10}deg)`;
+  };
+
+  const onPointerUp = () => {
+    if (!dragging) return;
+    dragging = false;
+    card.style.transition = '';
+    if (currentX > 100) {
+      like();
+    } else if (currentX < -100) {
+      dislike();
+    } else {
+      card.style.transform = '';
+    }
+    currentX = 0;
+  };
+
+  const like = () => {
+    liked.push(url);
+    removeCard();
+  };
+
+  const dislike = () => {
+    removeCard();
+  };
+
+  function removeCard() {
+    card.removeEventListener('pointerdown', onPointerDown);
+    card.removeEventListener('pointermove', onPointerMove);
+    card.removeEventListener('pointerup', onPointerUp);
+    card.removeEventListener('pointerleave', onPointerUp);
+    card.remove();
+    if (!deck.children.length) {
+      showSummary();
+    }
+  }
+
+  card.addEventListener('pointerdown', onPointerDown);
+  card.addEventListener('pointermove', onPointerMove);
+  card.addEventListener('pointerup', onPointerUp);
+  card.addEventListener('pointerleave', onPointerUp);
+
+  return card;
+}
+
+function showSummary() {
+  deck.classList.add('hidden');
+  summary.classList.remove('hidden');
+  liked.forEach((url) => {
+    const img = document.createElement('img');
+    img.src = url;
+    likedContainer.appendChild(img);
+  });
+}
+
+// Initialize deck
+document.addEventListener('DOMContentLoaded', () => {
+  images.slice().reverse().forEach((url) => deck.appendChild(createCard(url)));
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,43 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: #f5f5f5;
+}
+
+.deck {
+  position: relative;
+  width: 300px;
+  height: 400px;
+}
+
+.card {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  background-size: cover;
+  background-position: center;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.summary {
+  text-align: center;
+}
+
+.liked img {
+  width: 100px;
+  height: 100px;
+  object-fit: cover;
+  margin: 5px;
+  border-radius: 4px;
+}
+
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- Add main HTML entrypoint with deck container and hidden summary section
- Provide base CSS for deck cards and summary view
- Initialize swipe logic, image loading, and summary reveal in JavaScript

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b30112117483268191224301371e11